### PR TITLE
Fix Cargo.toml to allow for compilation on other machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ regex = "1.5.6"
 chrono = "0.4"
 tween = "2.0.0"
 strfmt = "0.2.2"
-enum-utils = "0.1.2"sudo port install x86_64-w64-mingw32-gcc
+enum-utils = "0.1.2"  # sudo port install x86_64-w64-mingw32-gcc
 
 [patch.crates-io]
 # Temp workaround until update in geng, as this issue is already fixed upstream
 # https://github.com/jdm/tinyfiledialogs-rs/issues/36
 tinyfiledialogs = { git = "https://github.com/kuviman/tinyfiledialogs-rs", branch = "fix-cross" }
-geng = { path = "/Users/admin/Documents/GitHub/geng/crates/geng" }
+geng = { git = "https://github.com/kuviman/geng", branch = "main" }


### PR DESCRIPTION
I was able to get the game to run on Linux!

![](https://user-images.githubusercontent.com/1540885/211741877-07c5423a-2731-4858-94a3-a909e3994a48.png)
